### PR TITLE
fix: allow session cookies for insecure LAN HTTP

### DIFF
--- a/config/initializers/security_headers.rb
+++ b/config/initializers/security_headers.rb
@@ -98,9 +98,14 @@ if ENV["HOME_ASSISTANT_ADDON"] == "true"
       same_site: :lax
   end
 else
+  # Local/LAN HTTP deployments explicitly opt in with RAILS_ALLOW_INSECURE_HTTP=true.
+  # In that mode, do not mark the session cookie Secure, otherwise browsers will
+  # refuse to store/send it over http:// and CSRF verification fails on sign-in.
+  allow_insecure_http = ENV["RAILS_ALLOW_INSECURE_HTTP"] == "true"
+
   Rails.application.config.session_store :cookie_store,
     key: "_homechat_session",
-    secure: Rails.env.production?,
+    secure: Rails.env.production? && !allow_insecure_http,
     httponly: true,
     same_site: :lax
 end


### PR DESCRIPTION
# PR title
fix: allow session cookies for insecure LAN HTTP

# PR body
## Summary
- Respect `RAILS_ALLOW_INSECURE_HTTP=true` when configuring production session cookies.
- Keep `Secure` session cookies for normal production deployments.
- Allow explicit trusted LAN/HTTP deployments to persist the Rails session cookie, avoiding CSRF failures during sign-in.

## Why
Production currently sets `_homechat_session` with the `Secure` flag whenever `HOME_ASSISTANT_ADDON` is not enabled. For a Docker/LAN deployment using `RAILS_ALLOW_INSECURE_HTTP=true`, browsers refuse to store/send that cookie over `http://`, so sign-in POSTs fail CSRF verification and users are redirected back to `/signin`.

Observed failure:

```text
ActionController::InvalidAuthenticityToken
Can't verify CSRF token authenticity
POST /signin -> 422 -> redirected back to /signin
```

## Verification
Ad-hoc verification, not full suite green:

```text
Syntax OK
cases={'production_lan_http': False, 'production_normal': True, 'development': False}
PASS: PR change keeps Secure cookies for normal production but disables Secure when RAILS_ALLOW_INSECURE_HTTP=true
```

Also verified against a live LAN Docker deployment:

```text
container_health=healthy
signin_status=200
cookies=[('_homechat_session', False, '/')]
login_final_url=http://192.168.1.188:3020/dashboard
login_final_status=200
body_has_login_form=False
PASS: HTTP session cookie is non-secure and admin login reaches /dashboard
```
