### PR TITLE
fix: require POST for DM and channel mutations

### DIFF
--- a/app/controllers/dms_controller.rb
+++ b/app/controllers/dms_controller.rb
@@ -2,19 +2,7 @@ class DmsController < ApplicationController
   before_action :require_login
 
   def new
-  end
-
-  # GET /dm/:username
-  # Finds or creates a DM with the given user and redirects to it
-  def start
-    username = params[:username].to_s.strip
-    target = User.find_by(username: username)
-    if target.nil? || target == current_user
-      redirect_to new_dm_path, alert: "Invalid user" and return
-    end
-
-    channel = find_or_create_dm(current_user, target)
-    redirect_to channel
+    @username = params[:username].to_s.strip
   end
 
   def create

--- a/app/helpers/messages_helper.rb
+++ b/app/helpers/messages_helper.rb
@@ -34,10 +34,11 @@ module MessagesHelper
       %(<a href="#{url}" target="_blank" rel="noopener" class="hc-link">#{url}</a>)
     end
 
-    # Mentions @username (alphanumeric + underscore) → link to start DM
+    # Mentions @username (alphanumeric + underscore) → link to the DM form.
+    # Creating the DM remains a POST-only action so message rendering never mutates state.
     escaped = escaped.gsub(/(^|\s)@([A-Za-z0-9_]{2,50})/) do
       prefix, name = Regexp.last_match(1), Regexp.last_match(2)
-      href = start_dm_path(username: name) rescue "#"
+      href = new_dm_path(username: name) rescue "#"
       %(#{prefix}<a href="#{href}" class="hc-mention-link">@#{name}</a>)
     end
 

--- a/app/views/dms/new.html.erb
+++ b/app/views/dms/new.html.erb
@@ -31,6 +31,7 @@
               <%= f.text_field :username, name: :username,
                   class: "block w-full pl-8 pr-3 py-3 border border-gray-300 rounded-lg shadow-sm placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-sm",
                   placeholder: "alex, sarah, john...",
+                  value: @username.presence,
                   required: true,
                   autocomplete: "off",
                   data: {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,7 +22,6 @@ Rails.application.routes.draw do
   # Channel routes
   resources :channels do
     member do
-      get :join
       post :join
       delete :leave
       post :invite
@@ -89,8 +88,6 @@ Rails.application.routes.draw do
   end
 
   resources :dms, only: [ :new, :create ]
-  # Quick-start a DM with a username
-  get "/dm/:username", to: "dms#start", as: :start_dm
 
   # API routes for Home Assistant integration
   namespace :api do

--- a/test/controllers/channels_controller_test.rb
+++ b/test/controllers/channels_controller_test.rb
@@ -111,6 +111,16 @@ class ChannelsControllerTest < ActionDispatch::IntegrationTest
     assert @channel.member?(other_user)
   end
 
+  test "get join route does not exist and does not add membership" do
+    other_user = create_user(username: "other_get_join")
+    sign_in_as(other_user)
+
+    assert_no_difference("ChannelMembership.count") do
+      get "/channels/#{@channel.id}/join"
+    end
+    assert_response :not_found
+  end
+
   test "should leave channel" do
     @channel.add_member(@user)
     sign_in_as(@user)

--- a/test/controllers/dms_controller_test.rb
+++ b/test/controllers/dms_controller_test.rb
@@ -12,6 +12,15 @@ class DmsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to signin_path
   end
 
+  test "new pre-fills username from query" do
+    sign_in_as(@user)
+
+    get new_dm_path(username: @target.username)
+
+    assert_response :success
+    assert_select "input[name='username'][value=?]", @target.username
+  end
+
   test "creates dm channel with both users and stable name" do
     sign_in_as(@user)
 
@@ -54,8 +63,17 @@ class DmsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to new_dm_path
 
     assert_no_difference("Channel.count") do
-      get start_dm_path(username: "missing-user")
+      post dms_path, params: { username: "missing-user" }
     end
     assert_redirected_to new_dm_path
+  end
+
+  test "get dm username route does not exist and does not create dm" do
+    sign_in_as(@user)
+
+    assert_no_difference("Channel.count") do
+      get "/dm/#{@target.username}"
+    end
+    assert_response :not_found
   end
 end

--- a/test/helpers/messages_helper_test.rb
+++ b/test/helpers/messages_helper_test.rb
@@ -47,6 +47,6 @@ class MessagesHelperTest < ActionView::TestCase
     text = "Hey @alice check this"
     result = render_message_body(text)
     assert result.include?("@alice")
-    assert result.include?("<a href=")
+    assert result.include?(%(href="#{new_dm_path(username: "alice")}"))
   end
 end


### PR DESCRIPTION
## Summary
- remove the GET channel join route so joining a channel remains POST-only
- remove the GET /dm/:username route that created direct-message channels
- route @mention links to the non-mutating new DM form with username prefilled
- add regression coverage that removed GET routes no longer create memberships/channels

## Verification
- docker-compose -p homechat_review run --rm -e RAILS_ENV=test web bash -lc 'bin/rails db:prepare && bin/rails test test/controllers/channels_controller_test.rb test/controllers/dms_controller_test.rb test/helpers/messages_helper_test.rb'\n  - 30 runs, 132 assertions, 0 failures, 0 errors, 0 skips\n- docker-compose -p homechat_review run --rm -e RAILS_ENV=test web bash -lc 'bin/rails tailwindcss:build && bin/rails db:prepare && bin/rails test && bundle exec rubocop --fail-level error'\n  - Rails tests: 658 runs, 2105 assertions, 0 failures, 0 errors, 4 skips\n  - RuboCop: exit 0 at CI fail-level error; existing convention warnings remain\n- docker-compose -p homechat_review run --rm -e RAILS_ENV=test web bash -lc 'bundle exec brakeman --quiet --no-pager'\n  - Security Warnings: 0