### PR TITLE
ci: enforce stronger merge gates

### DIFF
--- a/.github/workflows/api-contract-check.yml
+++ b/.github/workflows/api-contract-check.yml
@@ -69,9 +69,11 @@ jobs:
         with:
           path: homechat
 
-      - name: Skip when cross-repo token is unavailable
+      - name: Require cross-repo token for mobile DTO drift checks
         if: ${{ env.CROSS_REPO_PAT == '' }}
-        run: echo "::notice::Skipping mobile DTO drift check because CROSS_REPO_PAT is not configured."
+        run: |
+          echo "::error::CROSS_REPO_PAT is required so mobile DTO drift checks cannot silently skip."
+          exit 1
 
       - name: Checkout Android repo
         if: ${{ env.CROSS_REPO_PAT != '' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           bundler-cache: true
 
       - name: Scan for common Rails security vulnerabilities using static analysis
-        run: bin/brakeman --no-pager --config-file config/brakeman.yml
+        run: bundle exec brakeman --no-pager --config-file config/brakeman.yml
 
       - name: Security audit for Ruby gems
         run: bundle exec bundle-audit check --update
@@ -117,6 +117,9 @@ jobs:
 
       - name: Prepare database
         run: bin/rails db:prepare
+
+      - name: Build Tailwind assets for tests
+        run: bin/rails tailwindcss:build
 
       - name: Run tests with coverage
         run: COVERAGE=1 bin/rails test

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -21,6 +21,5 @@ jobs:
         uses: actions/dependency-review-action@v4
         with:
           fail-on-severity: moderate
-          allow-licenses: MIT, Apache-2.0, BSD-3-Clause, BSD-2-Clause, ISC, 0BSD
           deny-licenses: GPL-2.0, GPL-3.0, AGPL-1.0, AGPL-3.0, LGPL-2.0, LGPL-2.1, LGPL-3.0
           comment-summary-in-pr: always

--- a/.github/workflows/mobile-integration.yml
+++ b/.github/workflows/mobile-integration.yml
@@ -49,9 +49,11 @@ jobs:
       CROSS_REPO_PAT: ${{ secrets.CROSS_REPO_PAT }}
 
     steps:
-      - name: Skip when cross-repo token is unavailable
+      - name: Require cross-repo token for Android contract tests
         if: ${{ env.CROSS_REPO_PAT == '' }}
-        run: echo "::notice::Skipping Android contract tests because CROSS_REPO_PAT is not configured."
+        run: |
+          echo "::error::CROSS_REPO_PAT is required so Android contract tests cannot silently skip."
+          exit 1
 
       - name: Checkout Android repo
         if: ${{ env.CROSS_REPO_PAT != '' }}
@@ -84,9 +86,11 @@ jobs:
       CROSS_REPO_PAT: ${{ secrets.CROSS_REPO_PAT }}
 
     steps:
-      - name: Skip when cross-repo token is unavailable
+      - name: Require cross-repo token for iOS contract tests
         if: ${{ env.CROSS_REPO_PAT == '' }}
-        run: echo "::notice::Skipping iOS contract tests because CROSS_REPO_PAT is not configured."
+        run: |
+          echo "::error::CROSS_REPO_PAT is required so iOS contract tests cannot silently skip."
+          exit 1
 
       - name: Checkout iOS repo
         if: ${{ env.CROSS_REPO_PAT != '' }}

--- a/.github/workflows/mobile-ui-smoke.yml
+++ b/.github/workflows/mobile-ui-smoke.yml
@@ -1,4 +1,4 @@
-name: iOS UI Smoke (Non-blocking)
+name: iOS UI Smoke
 
 on:
   pull_request:
@@ -21,9 +21,11 @@ jobs:
       CROSS_REPO_PAT: ${{ secrets.CROSS_REPO_PAT }}
 
     steps:
-      - name: Skip when cross-repo token is unavailable
+      - name: Require cross-repo token for iOS UI smoke tests
         if: ${{ env.CROSS_REPO_PAT == '' }}
-        run: echo "::notice::Skipping iOS UI smoke because CROSS_REPO_PAT is not configured."
+        run: |
+          echo "::error::CROSS_REPO_PAT is required so iOS UI smoke tests cannot silently skip."
+          exit 1
 
       - name: Checkout iOS repo
         if: ${{ env.CROSS_REPO_PAT != '' }}
@@ -33,10 +35,9 @@ jobs:
           path: homechat-ios
           token: ${{ env.CROSS_REPO_PAT }}
 
-      - name: Run HomeChat iOS UI tests (non-blocking)
+      - name: Run HomeChat iOS UI tests
         if: ${{ env.CROSS_REPO_PAT != '' }}
         working-directory: homechat-ios
-        continue-on-error: true
         run: |
           mkdir -p TestResults
           xcodebuild \

--- a/.github/workflows/security-advanced.yml
+++ b/.github/workflows/security-advanced.yml
@@ -100,6 +100,22 @@ jobs:
           sarif_file: hadolint-dev-results.sarif
           category: 'hadolint-development'
 
+  production_docker_smoke:
+    name: Production Docker Smoke
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Run production Docker smoke test
+        run: scripts/ci-docker-smoke.sh
+
   secrets_scan:
     name: Secret Detection
     runs-on: ubuntu-latest

--- a/scripts/ci-docker-smoke.sh
+++ b/scripts/ci-docker-smoke.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+IMAGE_TAG="${IMAGE_TAG:-homechat:ci-smoke}"
+CONTAINER_NAME="${CONTAINER_NAME:-homechat-ci-smoke}"
+
+cleanup() {
+  docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+cleanup
+
+CI_SECRET_KEY_BASE="$(printf '0%.0s' {1..128})"
+CI_API_TOKEN_PEPPER="ci-smoke-api-token-pepper"
+
+DOCKER_BUILDKIT=1 docker build -t "$IMAGE_TAG" .
+
+docker run -d \
+  --name "$CONTAINER_NAME" \
+  -p 127.0.0.1::80 \
+  -e RAILS_ENV=production \
+  -e RAILS_LOG_TO_STDOUT=1 \
+  -e RAILS_SERVE_STATIC_FILES=true \
+  -e RAILS_ALLOW_INSECURE_HTTP=true \
+  -e SECRET_KEY_BASE="$CI_SECRET_KEY_BASE" \
+  -e API_TOKEN_PEPPER="$CI_API_TOKEN_PEPPER" \
+  -e AR_ENCRYPTION_PRIMARY_KEY=00000000000000000000000000000000 \
+  -e AR_ENCRYPTION_DETERMINISTIC_KEY=11111111111111111111111111111111 \
+  -e AR_ENCRYPTION_KEY_DERIVATION_SALT=22222222222222222222222222222222 \
+  -e DISCOVERY_MODE=cloud \
+  -e SOLID_QUEUE_IN_PUMA=false \
+  "$IMAGE_TAG"
+
+host_port=""
+for attempt in {1..60}; do
+  host_port="$(docker port "$CONTAINER_NAME" 80/tcp | sed -E 's/^.*:([0-9]+)$/\1/' | tail -1)"
+  if [[ -n "$host_port" ]] && curl -fsS "http://127.0.0.1:${host_port}/up" >/dev/null; then
+    echo "PASS: production container responded on /up via port ${host_port}"
+    curl -fsS -o /dev/null "http://127.0.0.1:${host_port}/signin"
+    echo "PASS: production container responded on /signin"
+    exit 0
+  fi
+
+  if ! docker ps --format '{{.Names}}' | grep -qx "$CONTAINER_NAME"; then
+    echo "Container exited before becoming healthy" >&2
+    docker logs "$CONTAINER_NAME" >&2 || true
+    exit 1
+  fi
+
+  sleep 2
+done
+
+echo "Container did not become ready" >&2
+docker logs "$CONTAINER_NAME" >&2 || true
+exit 1


### PR DESCRIPTION
## Summary
- build Tailwind assets before Rails tests so CI matches the passing local test command
- fix dependency-review configuration by using deny-licenses without an incompatible allow list
- fail mobile DTO/Android/iOS contract jobs when CROSS_REPO_PAT is unavailable instead of silently skipping
- make iOS UI smoke blocking instead of continue-on-error
- add a production Docker smoke job that builds the production image, boots it, and checks /up and /signin

## Local verification
- bash -n scripts/ci-docker-smoke.sh
- Python YAML parse for all .github/workflows/*.yml
- rhysd/actionlint:latest
- docker-compose -p homechat_review run --rm -e RAILS_ENV=test web bash -lc 'bin/rails db:prepare && bin/rails tailwindcss:build && COVERAGE=1 bin/rails test'\n  - 655 runs, 2091 assertions, 0 failures, 0 errors, 4 skips\n\n## Notes\n- Local host Docker cannot run BuildKit builds because the buildx component is missing; the workflow installs docker/setup-buildx-action before running the production Docker smoke test on GitHub-hosted runners.